### PR TITLE
ADC API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ libtock_low_level_debug = { path = "apis/low_level_debug" }
 libtock_platform = { path = "platform" }
 libtock_runtime = { path = "runtime" }
 libtock_temperature = { path = "apis/temperature" }
+libtock_adc = { path = "apis/adc"}
 
 [profile.dev]
 panic = "abort"
@@ -50,4 +51,5 @@ members = [
     "tools/print_sizes",
     "ufmt",
     "unittest",
+    "apis/adc",
 ]

--- a/apis/adc/Cargo.toml
+++ b/apis/adc/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "libtock_adc"
+version = "0.1.0"
+authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+license = "MIT/Apache-2.0"
+edition = "2021"
+repository = "https://www.github.com/tock/libtock-rs"
+description = "libtock adc driver"
+
+[dependencies]
+libtock_platform = { path = "../../platform" }
+
+[dev-dependencies]
+libtock_unittest = { path = "../../unittest" }

--- a/apis/adc/src/lib.rs
+++ b/apis/adc/src/lib.rs
@@ -1,0 +1,46 @@
+#![no_std]
+
+//use core::cell::Cell;
+use libtock_platform::{
+    share, subscribe::OneId, CommandReturn, DefaultConfig, ErrorCode, Subscribe, Syscalls, Upcall,
+};
+
+pub struct Adc<S: Syscalls>(S);
+
+impl<S: Syscalls> Adc<S> {
+    pub fn count(x: &mut u32) -> Result<(), ErrorCode> {
+        match S::command(DRIVER_NUM, COUNT, 0, 0).get_success_u32() {
+            Some(value) => {
+                *x = value;
+                Ok(())
+            }
+            None => Err(ErrorCode::Fail),
+        }
+    }
+
+    pub fn exists() -> Result<(), ErrorCode> {
+        let mut check = 0;
+        match Self::count(&mut check) {
+            Ok(_) if check >= 1 => Ok(()),
+            Ok(_) => Err(ErrorCode::Fail),
+            Err(_) => Err(ErrorCode::Fail),
+        }
+    }
+}
+
+pub struct AdcListener<F: Fn(i32)>(pub F);
+impl<F: Fn(i32)> Upcall<OneId<DRIVER_NUM, 0>> for AdcListener<F> {
+    fn upcall(&self, adc_val: u32, _arg1: u32, _arg2: u32) {
+        self.0(adc_val as i32)
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Driver number and command IDs
+// -----------------------------------------------------------------------------
+
+const DRIVER_NUM: u32 = 0x00005;
+
+// Command IDs
+
+const COUNT: u32 = 0;

--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -1,0 +1,22 @@
+#![no_main]
+#![no_std]
+
+use core::fmt::Write;
+use libtock::console::Console;
+
+use libtock::adc::Adc;
+use libtock::runtime::{set_main, stack_size};
+
+set_main! {main}
+stack_size! {0x200}
+
+fn main() {
+    // let mut data = 0;
+    match Adc::exists() {
+        Ok(()) => writeln!(Console::writer(), "adc driver available").unwrap(),
+        Err(_) => {
+            writeln!(Console::writer(), "adc driver unavailable").unwrap();
+            return;
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,3 +44,9 @@ pub mod temperature {
     pub type Temperature = temperature::Temperature<super::runtime::TockSyscalls>;
     pub use temperature::TemperatureListener;
 }
+
+pub mod adc {
+    use libtock_adc as adc;
+    pub type Adc = adc::Adc<super::runtime::TockSyscalls>;
+    pub use adc::AdcListener;
+}


### PR DESCRIPTION
Starting working on ADC API implementation #10 based on the [libtock-c](https://github.com/tock/libtock-c/blob/master/libtock/adc.h) 

Implemented so far:
- driver API: 
  - count( get all the adc channels and changes the value provided, used for exists)
  - exists ( because of the syscall S::command(DRIVER_NUM,0,0,0) returns the number of adc channels, we verify that the number is greater than 0 , dependent on count )
- simple adc example to test if the driver is available