### PR TITLE
CI update macos runner deprecated

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -18,6 +18,7 @@ jobs:
         run: |
           make -j2 EXAMPLE=leds apollo3
           make -j2 EXAMPLE=leds hail
+          make -j2 EXAMPLE=leds imix
           make -j2 EXAMPLE=leds nucleo_f429zi
           make -j2 EXAMPLE=leds nucleo_f446re
           make -j2 EXAMPLE=leds nrf52840
@@ -29,6 +30,7 @@ jobs:
         run: |
           make -j2 EXAMPLE=low_level_debug apollo3
           make -j2 EXAMPLE=low_level_debug hail
+          make -j2 EXAMPLE=low_level_debug imix
           make -j2 EXAMPLE=low_level_debug nucleo_f429zi
           make -j2 EXAMPLE=low_level_debug nucleo_f446re
           make -j2 EXAMPLE=low_level_debug nrf52840

--- a/.github/workflows/mac-os.yml
+++ b/.github/workflows/mac-os.yml
@@ -8,7 +8,7 @@ on: pull_request
 
 jobs:
   ci-mac-os:
-    runs-on: macos-10.15
+    runs-on: macos-latest
 
     steps:
       # Clones a single commit from the libtock-rs repository. The commit cloned

--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,21 @@ flash-hail:
 	LIBTOCK_PLATFORM=hail cargo run --example $(EXAMPLE) $(features) \
 		--target=thumbv7em-none-eabi $(release) -- --deploy=tockloader
 
+.PHONY: imix
+imix:
+	LIBTOCK_PLATFORM=imix cargo run --example $(EXAMPLE) $(features) \
+		--target=thumbv7em-none-eabi $(release)
+	mkdir -p target/tbf/imix
+	cp target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tab \
+		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tbf \
+		target/tbf/imix
+
+.PHONY: flash-imix
+flash-imix:
+	LIBTOCK_PLATFORM=imix cargo run --example $(EXAMPLE) $(features) \
+		--target=thumbv7em-none-eabi $(release) -- --deploy=tockloader
+
+
 .PHONY: microbit_v2
 microbit_v2:
 	LIBTOCK_PLATFORM=microbit_v2 cargo run --example $(EXAMPLE) $(features) \

--- a/runner/src/tockloader.rs
+++ b/runner/src/tockloader.rs
@@ -10,7 +10,7 @@ use std::process::{Child, Command, Stdio};
 pub fn deploy(cli: &Cli, platform: String, tab_path: PathBuf) -> Child {
     let flags: &[_] = match platform.as_str() {
         "clue_nrf52840" => &[],
-        "hail" => &[],
+        "hail" | "imix" => &[],
         "microbit_v2" => &["--bundle-apps"],
         "nrf52" | "nrf52840" => &[
             "--jlink",
@@ -31,9 +31,9 @@ pub fn deploy(cli: &Cli, platform: String, tab_path: PathBuf) -> Child {
     // varies from platform to platform. We look up the platform, and if it is
     // not satisfactorily reliable we output a warning for the user.
     let reliable_listen = match platform.as_str() {
-        // tockloader listen will reset the Hail, allowing it to capture all
+        // tockloader listen will reset the Hail/Imix, allowing it to capture all
         // printed messages.
-        "hail" => true,
+        "hail" | "imix" => true,
 
         // Microbit uses CDC over USB, which buffers messages so that tockloader
         // listen can receive messages sent before it was started. As long as


### PR DESCRIPTION
## This PR resolves
There is a issue with the CI because the ```macos-10.15``` runner has been deprecated and it gets timed out in a day
I suggest using the ```macos-latest``` in order to have always the latest LTS version for the runner